### PR TITLE
更新 MultiLogin.md

### DIFF
--- a/docs/yggdrasil/multilogin.md
+++ b/docs/yggdrasil/multilogin.md
@@ -18,7 +18,7 @@ outline: [2, 3]
 >
 > 我们始终建议你使用 [最新版](https://github.com/CaaMoe/MultiLogin/releases) (Velocity)
 > 
-> Velocity配置教程: [点击这里](#velocity)
+> Velocity 配置教程: [点击这里](#velocity)
 
 我们建议直接参考 MultiLogin 的 [GitHub Wiki](https://github.com/CaaMoe/MultiLogin/wiki#%E7%AE%80%E5%8D%95%E9%85%8D%E7%BD%AE)。
 

--- a/docs/yggdrasil/multilogin.md
+++ b/docs/yggdrasil/multilogin.md
@@ -12,7 +12,13 @@ outline: [2, 3]
 
 <!-- @include: @/pay-for-minecraft.template.md -->
 
-## 单服务端
+## 单服务端<Badge type="warning" text="过时" />
+> [!WARNING] 提示
+> MultiLogin 自 0.6.12 版本后不再分发 Bukkit、Bungee 的本体，且在后续暂停维护
+>
+> 我们始终建议你使用 [最新版](https://github.com/CaaMoe/MultiLogin/releases) (Velocity)
+> 
+> Velocity配置教程: [点击这里](#velocity)
 
 我们建议直接参考 MultiLogin 的 [GitHub Wiki](https://github.com/CaaMoe/MultiLogin/wiki#%E7%AE%80%E5%8D%95%E9%85%8D%E7%BD%AE)。
 

--- a/docs/yggdrasil/multilogin.md
+++ b/docs/yggdrasil/multilogin.md
@@ -16,9 +16,7 @@ outline: [2, 3]
 > [!WARNING] 提示
 > MultiLogin 自 0.6.12 版本后不再分发 Bukkit、Bungee 的本体，且在后续暂停维护
 >
-> 我们始终建议你使用 [最新版](https://github.com/CaaMoe/MultiLogin/releases) (Velocity)
-> 
-> Velocity 配置教程: [点击这里](#velocity)
+> 我们建议您 [改用 Velocity](#velocity) 以获得更好的体验。
 
 我们建议直接参考 MultiLogin 的 [GitHub Wiki](https://github.com/CaaMoe/MultiLogin/wiki#%E7%AE%80%E5%8D%95%E9%85%8D%E7%BD%AE)。
 


### PR DESCRIPTION
从 0.6.12 版本开始 MultiLogin 将不再分发 Bukkit、Bungee 的本体，且后续暂停维护 用户可以使用早期版本，但永远建议使用最新版本